### PR TITLE
ENV variable for controlling min_severity in trigger.get

### DIFF
--- a/scripts/hubot-zabbix.coffee
+++ b/scripts/hubot-zabbix.coffee
@@ -5,6 +5,7 @@
 #   HUBOT_ZABBIX_USER
 #   HUBOT_ZABBIX_PASSWORD
 #   HUBOT_ZABBIX_ENDPOINT
+#   HUBOT_ZABBIX_MIN_SEVERITY
 #
 # Commands:
 #   hubot auth to zabbix - let hubot to re-logging in to zabbix
@@ -173,6 +174,7 @@ module.exports = (robot) ->
       selectHosts: 'extend',
       selectLastEvent: 'extend', 
       expandDescription: true,
+      min_severity: process.env.HUBOT_ZABBIX_MIN_SEVERITY || 2
       monitored: true
     }
 

--- a/scripts/hubot-zabbix.coffee
+++ b/scripts/hubot-zabbix.coffee
@@ -174,7 +174,7 @@ module.exports = (robot) ->
       selectHosts: 'extend',
       selectLastEvent: 'extend', 
       expandDescription: true,
-      min_severity: process.env.HUBOT_ZABBIX_MIN_SEVERITY || 2
+      min_severity: process.env.HUBOT_ZABBIX_MIN_SEVERITY || 2,
       monitored: true
     }
 


### PR DESCRIPTION
We have a lot of active triggers - in order for this script to respond without huge delays and / or flooding our rooms it is very beneficial to be able to control the minimum severity for the returned active triggers.

See the min_severity parameter for trigger.get for more info :

https://www.zabbix.com/documentation/2.2/manual/api/reference/trigger/get
